### PR TITLE
Fix R package installation for package 'markovchain'

### DIFF
--- a/packages.r
+++ b/packages.r
@@ -65,6 +65,7 @@ devtools::install_url("https://cran.r-project.org/src/contrib/Archive/slam/slam_
 devtools::install_url("https://cran.r-project.org/src/contrib/Archive/arules/arules_1.5-0.tar.gz")
 devtools::install_url("https://cran.r-project.org/src/contrib/Archive/proxy/proxy_0.4-16.tar.gz")
 devtools::install_url("https://cran.r-project.org/src/contrib/Archive/tm/tm_0.7-1.tar.gz")
+devtools::install_url("https://cran.r-project.org/src/contrib/Archive/markovchain/markovchain_0.6.9.11.tar.gz")
 
 ## install from BioConductor
 p <- filter.installed.packages(c("BiRewire", "graph"))
@@ -82,7 +83,7 @@ p <- filter.installed.packages(c("statnet", "tm", "optparse", "arules", "data.ta
                                  "corrgram", "logging", "png", "rjson", "lsa", "RJSONIO",
                                  "GGally", "corrplot", "psych", "markovchain", "hashmap"))
 if(length(p) > 0) {
-    install.packages(p, dependencies=T, verbose=F, quiet=T, Ncpus=num.cores)
+    install.packages(p, dependencies=T, verbose=F, quiet=F, Ncpus=num.cores)
 }
 
 ## Install following packages from different sources


### PR DESCRIPTION
As the newest version of the R package 'markovchain' is not compatible
with R version < 3.5, we need to manually need to make sure that a
compatible version for lower versions (as on TravisCI) is installed. See
also https://travis-ci.org/se-passau/codeface/builds/421118750.

Additionally, the flag 'quiet' on R package installations is set to
'FALSE' to ensure that installation problems can be identified earlier.

Signed-off-by: Claus Hunsen <hunsen@fim.uni-passau.de>